### PR TITLE
migration(etablissement): Affichage de la page établissement

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,18 @@
+Tu es un expert des technologies web, notamment Zend Framework (version 1) et Symfony (version 4).
+Tu interviens dans le cadre de la migration d’une application Zend v1 située dans le répertoire prevarisc vers une application Symfony v4 située dans le répertoire prevarisc-migration.
+Ton rôle consiste à convertir le code en respectant les règles de gestion et les spécifications fonctionnelles, sauf indication contraire explicitement donnée par l’utilisateur.
+
+Les templates PHTML doivent être convertis en Twig (version 2), en utilisant Bootstrap 3.
+Les fichiers PHP doivent être adaptés pour fonctionner avec Symfony.
+
+Lors de la génération du code, suis les instructions suivantes :
+
+Génère le code en fonction de la version indiquée dans le fichier composer.json du projet.
+Pour exécuter une commande PHP sur l’application Symfony, lance-la depuis le conteneur Docker nommé prevarisc-infra-app-1, dans le répertoire /var/www/html/prevarisc-migration.
+Pour exécuter une commande PHP sur l’application Zend, lance-la depuis le conteneur Docker nommé prevarisc-infra-app-1, dans le répertoire /var/www/html/prevarisc.
+
+Une fois la génération terminée, analyse le code en exécutant les commandes suivantes depuis la machine hôte :
+
+Analyse avec PHPStan : castor symfony:analyse
+Rector et CodingStyle : castor symfony:cs
+Tests PHPUnit : castor symfony:test

--- a/php/prevarisc/Dockerfile
+++ b/php/prevarisc/Dockerfile
@@ -34,6 +34,7 @@ RUN a2enmod authz_core deflate dir ssl headers expires include rewrite \
         gd \
         ldap \
         exif \
+        intl \
         xdebug
 
 COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer

--- a/php/prevarisc/Dockerfile
+++ b/php/prevarisc/Dockerfile
@@ -34,7 +34,6 @@ RUN a2enmod authz_core deflate dir ssl headers expires include rewrite \
         gd \
         ldap \
         exif \
-        intl \
         xdebug
 
 COPY --from=composer:2.2 /usr/bin/composer /usr/bin/composer


### PR DESCRIPTION
This pull request introduces new instructions for migrating a Zend Framework v1 application to Symfony v4 and updates the Dockerfile for the `prevarisc` application to include the `intl` PHP extension. The main focus is on guiding the migration process and ensuring the development environment is properly configured.

Migration instructions and guidelines:

* Added a detailed `.github/copilot-instructions.md` file outlining the migration process from Zend v1 (`prevarisc`) to Symfony v4 (`prevarisc-migration`). This includes rules for converting PHTML templates to Twig, adapting PHP files, and running analysis and test commands.

Development environment update:

* Updated `php/prevarisc/Dockerfile` to install the `intl` PHP extension, which is often required for internationalization and proper Symfony functionality.