### PR TITLE
chore(gitignore): ancrer les patterns prevarisc/ au root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,9 @@ apache/httpd-prevarisc-config.conf
 apache/httpd-prevarisc-version.conf
 apache/httpd-auth-worktree.conf
 apache/httpd-auth-main.conf
-prevarisc/
-prevarisc-passerelle-platau/
-prevarisc-migration/
+/prevarisc/
+/prevarisc-passerelle-platau/
+/prevarisc-migration/
 .castor/.castor.stub.php
 /docs/*.md
 /*.sql


### PR DESCRIPTION
Les patterns non ancrés matchaient aussi php/prevarisc/ et tout sous-répertoire nommé prevarisc. Ajout du / de tête pour restreindre au root du repo.